### PR TITLE
Change log level for salt-call in provision script

### DIFF
--- a/provision
+++ b/provision
@@ -27,7 +27,14 @@ git archive --remote=ssh://$PILLAR_GIT_URL --format=tgz master | tar xvz -C /opt
 mkdir -p /srv
 ln -sf /opt/magudi/salt/roots /srv/salt
 ln -sf /opt/pillar /srv/pillar
-salt-call --local state.highstate -l debug
+
+if [ "$1" = "--debug" ]; then
+  LOG_LEVEL="debug"
+else
+  LOG_LEVEL="warning"  # The default
+fi
+
+salt-call --local state.highstate -l $LOG_LEVEL
 
 # Ensure that next run will have the updated version
 # of the this file. Self updating!!!


### PR DESCRIPTION
In the `provision` script, `salt-call` runs with a log level of *debug*, which leads to it logging some sensitive credentials on standard output.

This makes it difficult to use `provision` on a CI system. Even while running manually, people often redirect a command's output to a log file (provision >> provisioning.log). That can also lead to credentials getting leaked inadvertently.

With this change, while executing normally, the `provision` script does not log any credentials. And whenever a detailed log is needed, it can be run with a debug flag (`provision --debug`)


