### PR TITLE
Update SSL certificate location

### DIFF
--- a/salt/roots/inpycon/in.pycon.org.with_ssl.conf
+++ b/salt/roots/inpycon/in.pycon.org.with_ssl.conf
@@ -5,8 +5,8 @@ if ($scheme = http) {
     rewrite ^(.*) https://$server_name$1 permanent;
 }
 
-ssl_certificate /etc/ssl/in.pycon.org.2016.fullchain.pem;
-ssl_certificate_key /etc/ssl/in.pycon.org.2016.pvtkey.pem;
+ssl_certificate /etc/letsencrypt/live/in.pycon.org/fullchain.pem;
+ssl_certificate_key /etc/letsencrypt/live/in.pycon.org/privkey.pem;
 ssl_dhparam /etc/ssl/dhparam.pem;
 
 # Recomended settings form


### PR DESCRIPTION
The older SSL certificates were not directly managed by Certbot
and hence were tedious to manage.

Provisioned a Certbot managed certificate

**TODO:** Certbot cronjob to renew certificates whenever necessary.